### PR TITLE
Pause playback when battery is empty

### DIFF
--- a/player/missioncontrol.cpp
+++ b/player/missioncontrol.cpp
@@ -62,6 +62,9 @@ void MissionControl::setRegistry(MafwRegistryAdapter *mafwRegistry)
     QDBusConnection::systemBus().connect("", "", "com.nokia.mce.signal", "sig_call_state_ind",
                                          this, SLOT(onCallStateChanged(QDBusMessage)));
 
+    QDBusConnection::systemBus().connect("", "", "com.nokia.bme.signal", "battery_empty",
+                                         this, SLOT(onBatteryEmpty()));
+
     updateWiredHeadset();
 }
 
@@ -180,6 +183,12 @@ void MissionControl::onStateChanged(MafwPlayState state)
         headsetPauseStamp = -1;
         pausedByCall = false;
     }
+}
+
+void MissionControl::onBatteryEmpty()
+{
+    if (mafwState == Playing)
+        mafwRenderer->pause();
 }
 
 void MissionControl::onCallStateChanged(QDBusMessage msg)

--- a/player/missioncontrol.h
+++ b/player/missioncontrol.h
@@ -68,6 +68,8 @@ private slots:
     void onStatusReceived(MafwPlaylist *, uint, MafwPlayState state);
     void onStateChanged(MafwPlayState state);
 
+    void onBatteryEmpty();
+
     void onCallStateChanged(QDBusMessage msg);
 
     void onWirelessHeadsetConnected();


### PR DESCRIPTION
My old patch which I was unable to send because gitorious died...

Useful when you have connected bluetooth headset and Maemo decide to turn off phone due to empty battery. In shutdown sequence bluetooth is disconnected before MAFW is stopped which can cause laud playback from N900 speakers.